### PR TITLE
Fix for banktransfer

### DIFF
--- a/src/CcvOnlinePaymentsApi.php
+++ b/src/CcvOnlinePaymentsApi.php
@@ -171,6 +171,8 @@ class CcvOnlinePaymentsApi {
             "billingState"              => $request->getBillingState(),
             "billingPostalCode"         => $request->getBillingPostalCode(),
             "billingCountry"            => $request->getBillingCountry(),
+            # Missing billingEmail
+            "billingEmail"              => $request->getAccountInfoEmail(),
             "billingHouseNumber"        => $request->getBillingHouseNumber(),
             "billingHouseExtension"     => $request->getBillingHouseExtension(),
             "billingPhoneNumber"        => $request->getBillingPhoneNumber(),
@@ -209,7 +211,16 @@ class CcvOnlinePaymentsApi {
 
         $paymentResponse = new PaymentResponse();
         $paymentResponse->setReference($apiResponse->reference);
-        $paymentResponse->setPayUrl($apiResponse->payUrl);
+        # Start modification
+        if($apiResponse->method == 'banktransfer'){
+          #payUrl does not exist for banktransfer
+          $paymentResponse->setPayUrl($apiResponse->returnUrl);
+        }
+        else {
+          #Original code below:
+          $paymentResponse->setPayUrl($apiResponse->payUrl);
+        }
+        # End modification
         return $paymentResponse;
     }
 


### PR DESCRIPTION
Bug opened for months with support. Finally had to solve it myself.

Fixed for version 1.2.4 , as it's the one used for the plugin woocommerce. 
Not tested with other version