### PR TITLE
Update CcvOnlinePaymentsApi.php

### DIFF
--- a/src/CcvOnlinePaymentsApi.php
+++ b/src/CcvOnlinePaymentsApi.php
@@ -126,7 +126,7 @@ class CcvOnlinePaymentsApi {
         return $methods;
     }
 
-    public static function getSortedMethodIds( $countryCode = null) {
+    public static function getSortedMethodIds($countryCode = null) {
         $methodIds = [
             "ideal",
             "card_bcmc",

--- a/src/CcvOnlinePaymentsApi.php
+++ b/src/CcvOnlinePaymentsApi.php
@@ -126,7 +126,7 @@ class CcvOnlinePaymentsApi {
         return $methods;
     }
 
-    public static function getSortedMethodIds($countryCode = null) {
+    public static function getSortedMethodIds( $countryCode = null) {
         $methodIds = [
             "ideal",
             "card_bcmc",
@@ -141,7 +141,7 @@ class CcvOnlinePaymentsApi {
             "banktransfer"
         ];
 
-        if(strtoupper($countryCode) === "BE") {
+        if(strtoupper($countryCode ?? "") === "BE") {
             $methodIds[0] = "card_bcmc";
             $methodIds[1] = "ideal";
         }


### PR DESCRIPTION
Prevent PHP 8.x deprecation warnings.
Function strtoupper() requires a string as argument and cannot be null.